### PR TITLE
Rename GitHub organization: yooz-eco → yooz-labs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request or Idea
-    url: https://github.com/yooz-eco/yooz-roadmap/discussions/new?category=ideas
+    url: https://github.com/yooz-labs/yooz-roadmap/discussions/new?category=ideas
     about: Share your ideas and feature suggestions in Discussions
   - name: Ask a Question
-    url: https://github.com/yooz-eco/yooz-roadmap/discussions/new?category=q-a
+    url: https://github.com/yooz-labs/yooz-roadmap/discussions/new?category=q-a
     about: Get help from the community
   - name: General Discussion
-    url: https://github.com/yooz-eco/yooz-roadmap/discussions/new?category=general
+    url: https://github.com/yooz-labs/yooz-roadmap/discussions/new?category=general
     about: Discuss anything Yooz-related
   - name: Security Issue
     url: mailto:security@yooz.live

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ View our [public milestones](../../milestones) to see what we're working on and 
 
 - **Website:** [yooz.live](https://yooz.live)
 - **Documentation:** [docs.yooz.live](https://docs.yooz.live)
-- **Organization:** [github.com/yooz-eco](https://github.com/yooz-eco)
+- **Organization:** [github.com/yooz-labs](https://github.com/yooz-labs)
 
 ## License
 

--- a/docs/GITHUB-PROJECTS-SETUP.md
+++ b/docs/GITHUB-PROJECTS-SETUP.md
@@ -14,7 +14,7 @@ GitHub Projects provide a visual board view (similar to Trello) that helps:
 
 ### Project 1: Q4 2025 - Yooz Notes Beta
 
-1. Go to https://github.com/yooz-eco/yooz-roadmap
+1. Go to https://github.com/yooz-labs/yooz-roadmap
 2. Click the "Projects" tab
 3. Click "New project"
 4. Choose "Board" template
@@ -202,9 +202,9 @@ Q4 2025 - Yooz Notes Beta
 
 ## Quick Links
 
-- [Create new project](https://github.com/yooz-eco/yooz-roadmap/projects/new)
-- [View milestones](https://github.com/yooz-eco/yooz-roadmap/milestones)
-- [View issues](https://github.com/yooz-eco/yooz-roadmap/issues)
+- [Create new project](https://github.com/yooz-labs/yooz-roadmap/projects/new)
+- [View milestones](https://github.com/yooz-labs/yooz-roadmap/milestones)
+- [View issues](https://github.com/yooz-labs/yooz-roadmap/issues)
 - [GitHub Projects documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects)
 
 ---


### PR DESCRIPTION
## Summary
Update public roadmap references from `yooz-eco` to `yooz-labs`.

## Changes
- Updated README org links
- Updated issue template configuration
- Updated GitHub Projects setup documentation

## Files Changed (3)
- README.md
- .github/ISSUE_TEMPLATE/config.yml
- docs/GITHUB-PROJECTS-SETUP.md

## Technical Notes
GitHub redirects maintain continuity for public roadmap access.